### PR TITLE
Removed clone call by calling into_iter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 mod commands;
 mod tests;
-mod runner;
 use clap::Parser;
 use commands::combos::*;
 use indicatif::{ProgressBar, ProgressStyle};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod tests;
+mod runner;
 use clap::Parser;
 use commands::combos::*;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -40,7 +41,7 @@ fn main() -> Result<(), anyhow::Error> {
     let combo = get_combo(args)?;
     //let prog_bar = ProgressBar::new(sequence.len() as u64)
     //.with_style(ProgressStyle::with_template("{bar}  {pos}/{len} \n{msg}").unwrap());
-    for cmd in combo {
+    for cmd in combo.into_iter() {
         if !in_working_tree() {
             return Err(GitError::NotARepo.into());
         }
@@ -48,7 +49,7 @@ fn main() -> Result<(), anyhow::Error> {
         println!("-----------------------------------------------");
         let output = Command::new("pwsh")
             .arg("-Command")
-            .arg(cmd.clone())
+            .arg(&cmd)
             .output()
             .expect(format!("Failed to execute command in main {}", cmd).as_str());
 


### PR DESCRIPTION
The previous implementation used `for cmd in combo`, which creates a reference to the iterator. Instead, we can call `into_iter`, which consumes the Vec. Additionally, instead of calling `clone` for `cmd`, we can instead pass a reference to it, preventing extra memory allocations.