### PR TITLE
Added multiple platform support

### DIFF
--- a/src/commands/combos.rs
+++ b/src/commands/combos.rs
@@ -1,6 +1,7 @@
 use crate::Args;
 use crate::GitError;
-use std::process::Command;
+use crate::runner::PlatformRunner;
+
 
 pub fn commit(args: Args) -> Result<Vec<String>, GitError> {
     if let Some(msg) = args.msg {
@@ -56,10 +57,8 @@ pub fn current_branch() -> Result<String, GitError> {
     if !in_working_tree() {
         Err(GitError::NotARepo)
     } else {
-        let output = Command::new("pwsh")
-            .arg("-Command")
-            .arg("git branch --show-current")
-            .output()
+        let output = PlatformRunner::for_platform()
+            .execute("git branch --show-current")
             .expect("Failed to execute command in current_branch()");
 
         Ok(String::from_utf8_lossy(&output.stdout)
@@ -70,14 +69,8 @@ pub fn current_branch() -> Result<String, GitError> {
 }
 
 pub fn in_working_tree() -> bool {
-    let output = Command::new("pwsh")
-        .arg("-Command")
-        .arg("git rev-parse --is-inside-work-tree")
-        .output()
+    let output = PlatformRunner::for_platform()
+        .execute("git rev-parse --is-inside-work-tree")
         .expect("Failed to execute command in in_working_tree()");
-    if String::from_utf8_lossy(&output.stdout).as_ref().trim() == "true" {
-        true
-    } else {
-        false
-    }
+    String::from_utf8_lossy(&output.stdout).as_ref().trim() == "true"
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
 mod commands;
 mod tests;
+mod runner;
 use clap::Parser;
 use commands::combos::*;
-use indicatif::{ProgressBar, ProgressStyle};
+
 use std::io::{self, Write};
-use std::process::{Command, Termination};
+
+
+use crate::runner::PlatformRunner;
 //TODO: GOAL: add more combos, logging, tests,
 //TODO: NEXT: add support for other os/shells, refine pretty print
 //TODO: add CI between github and crates, deploy downloadable binaries
@@ -46,20 +49,12 @@ fn main() -> Result<(), anyhow::Error> {
         }
         println!("\nRunning {}", cmd);
         println!("-----------------------------------------------");
-        let output = Command::new("pwsh")
-            .arg("-Command")
-            .arg(cmd.clone())
-            .output()
-            .expect(format!("Failed to execute command in main {}", cmd).as_str());
+        let output = PlatformRunner::for_platform()
+            .execute(&cmd)
+            .unwrap_or_else(|_| panic!("Failed to execute command in main {}", cmd));
 
-        if output.status.success() {
-            //prog_bar.inc(1);
-            io::stdout().write_all(&output.stdout).unwrap();
-            io::stderr().write_all(&output.stderr).unwrap();
-        } else {
-            io::stdout().write_all(&output.stdout).unwrap();
-            io::stderr().write_all(&output.stderr).unwrap();
-        }
+        io::stdout().write_all(&output.stdout).unwrap();
+        io::stderr().write_all(&output.stderr).unwrap();
         io::stdout().flush().unwrap();
     }
     //prog_bar.finish_with_message("Done");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,0 +1,37 @@
+use std::process::{Output, Command};
+
+pub struct PlatformRunner {
+	executable: &'static str,
+	optional_args: &'static [&'static str]
+}
+impl PlatformRunner {
+	pub fn for_platform() -> PlatformRunner {
+		let operating_system = std::env::consts::OS;
+		match operating_system {
+			"windows" => PlatformRunner {
+				executable: "pwsh",
+				optional_args: &["-Command"]
+			},
+			"macos" => PlatformRunner {
+				executable: "zsh",
+				optional_args: &["-c"]
+			},
+			"linux" => PlatformRunner {
+				executable: "sh",
+				optional_args: &["-c"]
+			},
+			_ => panic!("Running on unsupported platform {}!", operating_system)
+		}
+	}
+
+	// This AsRef<str> allows this function to accept
+	// &String, String, or &str
+	pub fn execute<T: AsRef<str>>(&self, cmd: T) -> std::io::Result<Output> {
+		let mut runner = Command::new(self.executable);
+		for o in self.optional_args {
+			runner.arg(o);
+		}
+		runner.arg(cmd.as_ref());
+		runner.output()
+	}
+}

--- a/src/tests/tests.rs
+++ b/src/tests/tests.rs
@@ -1,7 +1,7 @@
-use std::fmt::format;
-use std::vec;
 
-use crate::GitError;
+
+
+
 
 use crate::commands::combos::*;
 use crate::Args;


### PR DESCRIPTION
Refactored all instances of `Command` to use a new struct, `PlatformRunner`. This `PlatformRunner` struct has a method called `for_platform`, which utilizes the `std::env::consts::OS` constant to determine which shell/args to use.

I also removed the branching in main.rs, as both branches were identical, which Clippy complained about.